### PR TITLE
Allow the path to the config file to be configurable

### DIFF
--- a/lib/flipflop/engine.rb
+++ b/lib/flipflop/engine.rb
@@ -1,6 +1,8 @@
 module Flipflop
   class Engine < ::Rails::Engine
     attr_accessor :rake_task_executing
+    class_attribute :config_file
+    self.config_file = "config/features.rb"
 
     isolate_namespace Flipflop
 
@@ -14,7 +16,7 @@ module Flipflop
     end
 
     initializer "flipflop.features_path" do |app|
-      app.paths.add("config/features.rb")
+      app.paths.add(config_file)
     end
 
     initializer "flipflop.features_reloader" do |app|
@@ -48,7 +50,7 @@ module Flipflop
     private
 
     def feature_reloader(app)
-      features = app.paths["config/features.rb"].existent
+      features = app.paths[config_file].existent
       ActiveSupport::FileUpdateChecker.new(features) do
         features.each { |path| load(path) }
       end

--- a/test/integration/flipflop_engine_test.rb
+++ b/test/integration/flipflop_engine_test.rb
@@ -1,0 +1,17 @@
+require File.expand_path("../../test_helper", __FILE__)
+
+describe 'Flipflop::Engine' do
+  before do
+    TestApp.new
+    @original_file = Flipflop::Engine.config_file
+    Flipflop::Engine.config_file = 'test/foo'
+  end
+
+  after do
+    Flipflop::Engine.config_file = @original_file
+  end
+
+  it "sets the config file" do
+    assert_equal 'test/foo', Flipflop::Engine.config_file
+  end
+end


### PR DESCRIPTION
This allows us to do:

``` ruby
Flipflop::Engine.config_file = MyEngine::Engine.root + "config/features.rb"
```

Fixes #4
