### PR TITLE
There is no need to include the url_helpers on a controller

### DIFF
--- a/app/controllers/flipflop/strategies_controller.rb
+++ b/app/controllers/flipflop/strategies_controller.rb
@@ -1,15 +1,13 @@
 module Flipflop
   class StrategiesController < ApplicationController
-    include Engine.routes.url_helpers
-
     def update
       strategy.switch!(feature_key, enable?)
-      redirect_to(flipflop.features_url)
+      redirect_to(features_url)
     end
 
     def destroy
       strategy.clear!(feature_key)
-      redirect_to(flipflop.features_url)
+      redirect_to(features_url)
     end
 
     private


### PR DESCRIPTION
Furthermore, this allows a subclass to override features_url to set a custom redirect.
