### PR TITLE
Remove bootstrap from the gemspec

### DIFF
--- a/flipflop.gemspec
+++ b/flipflop.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
 if ENV["CONTINUOUS_INTEGRATION"]
   s.files         = `git ls-files`.split("\n").map { |f| f.sub(".scss", ".css") }
 else
-  s.add_dependency("bootstrap", "= 4.0.0.alpha3")
   s.files         = `git ls-files`.split("\n")
 end
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
It is in the Gemfile so that we can compile assets.  If it's left in the
gemspec, then referencing the gem from git causes bootstrap to be in the
dependency chain.
