### PR TITLE
Add rake tasks to manage features

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ application functionality at run-time. It is originally based on
 * simple configuration
 * ease of use for developers
 * an improved dashboard
+* manage features via console (using rake tasks)
 * thread safety
 * better database performance due to per-request caching, enabled by default
 * more strategies (Sequel, Redis, query strings, sessions, custom code)
@@ -32,9 +33,17 @@ Flipflop has a dashboard interface that's easy to understand and use.
 
 [<img src="https://raw.githubusercontent.com/voormedia/flipflop/screenshots/dashboard.png" alt="Dashboard">](https://raw.githubusercontent.com/voormedia/flipflop/screenshots/dashboard.png)
 
+If you prefer, you can use the included rake tasks to enable or disable features.
+
+```
+rake flipflop:features                    # Shows features table
+rake flipflop:turn_on[feature,strategy]   # Enables a feature with the specified strategy
+rake flipflop:turn_off[feature,strategy]  # Disables a feature with the specified strategy
+```
+
 ## Rails requirements
 
-This gem requires Rails 4, 5 or 6. Using an ORM layer is entirely optional. 
+This gem requires Rails 4, 5 or 6. Using an ORM layer is entirely optional.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ If you prefer, you can use the included rake tasks to enable or disable features
 rake flipflop:features                    # Shows features table
 rake flipflop:turn_on[feature,strategy]   # Enables a feature with the specified strategy
 rake flipflop:turn_off[feature,strategy]  # Disables a feature with the specified strategy
+rake flipflop:clear[feature,strategy]     # Clears a feature with the specified strategy
 ```
 
 ## Rails requirements

--- a/flipflop.gemspec
+++ b/flipflop.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.license  = "MIT"
 
   s.add_dependency("activesupport", ">= 4.0")
+  s.add_dependency('terminal-table', '>= 1.8')
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }

--- a/lib/tasks/flipflop.rake
+++ b/lib/tasks/flipflop.rake
@@ -26,18 +26,6 @@ namespace :flipflop do
 
   desc 'Shows features table'
   task features: :environment do
-    # Build features table...
-    rows = m.features.inject([]) do |array, feature|
-      row = [feature.name, feature.description]
-      m.strategies.each do |strategy|
-        row << m.status_label(strategy.enabled?(feature.key))
-      end
-      array << row
-    end
-
-    table = m.table_class.new headings: m.table_header, rows: rows
-
-    # Print table
-    puts table
+    puts m.build_features_table
   end
 end

--- a/lib/tasks/flipflop.rake
+++ b/lib/tasks/flipflop.rake
@@ -18,6 +18,12 @@ namespace :flipflop do
     puts "Feature :#{args[:feature]} disabled!"
   end
 
+  desc 'Clears a feature with the specified strategy.'
+  task :clear, %i[feature strategy] => :environment do |_task, args|
+    m.clear_feature! args[:feature], args[:strategy]
+    puts "Feature :#{args[:feature]} cleared!"
+  end
+
   desc 'Shows features table'
   task features: :environment do
     # Build features table...

--- a/lib/tasks/flipflop.rake
+++ b/lib/tasks/flipflop.rake
@@ -1,0 +1,37 @@
+require_relative 'support/methods'
+
+namespace :flipflop do
+  # Encapsulates support methods to prevent name collision with global
+  # rake namespace
+  m = Object.new
+  m.extend Flipflop::Rake::SupportMethods
+
+  desc 'Enables a feature with the specified strategy.'
+  task :turn_on, %i[feature strategy] => :environment do |_task, args|
+    m.switch_feature! args[:feature], args[:strategy], true
+    puts "Feature :#{args[:feature]} enabled!"
+  end
+
+  desc 'Disables a feature with the specified strategy.'
+  task :turn_off, %i[feature strategy] => :environment do |_task, args|
+    m.switch_feature! args[:feature], args[:strategy], false
+    puts "Feature :#{args[:feature]} disabled!"
+  end
+
+  desc 'Shows features table'
+  task features: :environment do
+    # Build features table...
+    rows = m.features.inject([]) do |array, feature|
+      row = [feature.name, feature.description]
+      m.strategies.each do |strategy|
+        row << m.status_label(strategy.enabled?(feature.key))
+      end
+      array << row
+    end
+
+    table = m.table_class.new headings: m.table_header, rows: rows
+
+    # Print table
+    puts table
+  end
+end

--- a/lib/tasks/support/methods.rb
+++ b/lib/tasks/support/methods.rb
@@ -1,0 +1,41 @@
+require 'terminal-table'
+
+module Flipflop
+  module Rake
+    module SupportMethods
+      def status_label(enabled)
+        enabled ? 'ON' : 'OFF'
+      end
+
+      def find_feature_by_name(name)
+        features.find { |f| f.name == name } || raise("Feature :#{name} is not defined.")
+      end
+
+      def find_strategy_by_name(name)
+        strategies.find { |s| s.name == name } || raise("Strategy :#{name} is not available.")
+      end
+
+      def table_header
+        %w[feature description] + strategies.map(&:name)
+      end
+
+      def table_class
+        Terminal::Table
+      end
+
+      def features
+        Flipflop.feature_set.features
+      end
+
+      def strategies
+        Flipflop.feature_set.strategies
+      end
+
+      def switch_feature!(feature_name, strategy_name, value)
+        feature = find_feature_by_name(feature_name)
+        strategy = find_strategy_by_name(strategy_name)
+        strategy.switch!(feature.key, value)
+      end
+    end
+  end
+end

--- a/lib/tasks/support/methods.rb
+++ b/lib/tasks/support/methods.rb
@@ -41,6 +41,13 @@ module Flipflop
           raise "The :#{strategy_name} strategy doesn't support switching."
         end
       end
+
+      def clear_feature!(feature_name, strategy_name)
+        feature = find_feature_by_name(feature_name)
+        strategy = find_strategy_by_name(strategy_name)
+
+        strategy.clear!(feature.key)
+      end
     end
   end
 end

--- a/lib/tasks/support/methods.rb
+++ b/lib/tasks/support/methods.rb
@@ -7,14 +7,6 @@ module Flipflop
         enabled.nil? ? '' : (enabled ? 'ON' : 'OFF')
       end
 
-      def find_feature_by_name(name)
-        features.find { |f| f.name == name } || raise("Feature :#{name} is not defined.")
-      end
-
-      def find_strategy_by_name(name)
-        strategies.find { |s| s.name == name } || raise("Strategy :#{name} is not available.")
-      end
-
       def table_header
         %w[feature description] + strategies.map(&:name)
       end
@@ -47,6 +39,16 @@ module Flipflop
         strategy = find_strategy_by_name(strategy_name)
 
         strategy.clear!(feature.key)
+      end
+
+      protected
+
+      def find_feature_by_name(name)
+        features.find { |f| f.name == name } || raise("Feature :#{name} is not defined.")
+      end
+
+      def find_strategy_by_name(name)
+        strategies.find { |s| s.name == name } || raise("Strategy :#{name} is not available.")
       end
     end
   end

--- a/lib/tasks/support/methods.rb
+++ b/lib/tasks/support/methods.rb
@@ -4,7 +4,7 @@ module Flipflop
   module Rake
     module SupportMethods
       def status_label(enabled)
-        enabled ? 'ON' : 'OFF'
+        enabled.nil? ? '' : (enabled ? 'ON' : 'OFF')
       end
 
       def find_feature_by_name(name)

--- a/lib/tasks/support/methods.rb
+++ b/lib/tasks/support/methods.rb
@@ -7,22 +7,6 @@ module Flipflop
         enabled.nil? ? '' : (enabled ? 'ON' : 'OFF')
       end
 
-      def table_header
-        %w[feature description] + strategies.map(&:name)
-      end
-
-      def table_class
-        Terminal::Table
-      end
-
-      def features
-        Flipflop.feature_set.features
-      end
-
-      def strategies
-        Flipflop.feature_set.strategies
-      end
-
       def switch_feature!(feature_name, strategy_name, value)
         feature = find_feature_by_name(feature_name)
         strategy = find_strategy_by_name(strategy_name)
@@ -41,7 +25,19 @@ module Flipflop
         strategy.clear!(feature.key)
       end
 
+      def build_features_table
+        table_class.new(headings: table_header, rows: table_rows)
+      end
+
       protected
+
+      def features
+        Flipflop.feature_set.features
+      end
+
+      def strategies
+        Flipflop.feature_set.strategies
+      end
 
       def find_feature_by_name(name)
         features.find { |f| f.name == name } || raise("Feature :#{name} is not defined.")
@@ -49,6 +45,26 @@ module Flipflop
 
       def find_strategy_by_name(name)
         strategies.find { |s| s.name == name } || raise("Strategy :#{name} is not available.")
+      end
+
+      def table_header
+        %w[feature description] + strategies.map(&:name)
+      end
+
+      def table_class
+        Terminal::Table
+      end
+
+      def table_rows
+        features.inject([]) do |array, feature|
+          array << build_row_for(feature)
+        end
+      end
+
+      def build_row_for(feature)
+        strategies.inject([feature.name, feature.description]) do |row, strategy|
+          row << status_label(strategy.enabled?(feature.key))
+        end
       end
     end
   end

--- a/lib/tasks/support/methods.rb
+++ b/lib/tasks/support/methods.rb
@@ -34,7 +34,12 @@ module Flipflop
       def switch_feature!(feature_name, strategy_name, value)
         feature = find_feature_by_name(feature_name)
         strategy = find_strategy_by_name(strategy_name)
-        strategy.switch!(feature.key, value)
+
+        if strategy.switchable?
+          strategy.switch!(feature.key, value)
+        else
+          raise "The :#{strategy_name} strategy doesn't support switching."
+        end
       end
     end
   end

--- a/test/unit/tasks/support/methods_test.rb
+++ b/test/unit/tasks/support/methods_test.rb
@@ -21,19 +21,19 @@ describe Flipflop::Rake::SupportMethods do
     end
   end
 
-  describe '#switch_feature!' do
-    def with_feature_and_strategy(strategy = 'Test')
-      # Stubs finder methods to avoid going into FeatureSet code.
-      feature = Flipflop::FeatureDefinition.new(:world_domination)
-      subject.stub :find_feature_by_name, feature do
-        classname = "#{strategy}Strategy"
-        strategy = Flipflop::Strategies.const_get(classname).new(name: strategy)
-        subject.stub :find_strategy_by_name, strategy do
-          yield(strategy, feature) if block_given?
-        end
+  def with_feature_and_strategy(strategy = 'Test')
+    # Stubs finder methods to avoid going into FeatureSet code.
+    feature = Flipflop::FeatureDefinition.new(:world_domination)
+    subject.stub :find_feature_by_name, feature do
+      classname = "#{strategy}Strategy"
+      strategy = Flipflop::Strategies.const_get(classname).new(name: strategy)
+      subject.stub :find_strategy_by_name, strategy do
+        yield(strategy, feature) if block_given?
       end
     end
+  end
 
+  describe '#switch_feature!' do
     it 'enables a feature using a strategy' do
       with_feature_and_strategy do |strategy, feature|
         subject.switch_feature! 'world_domination', 'test', true
@@ -48,18 +48,20 @@ describe Flipflop::Rake::SupportMethods do
       end
     end
 
-    it 'clears a feature using a strategy' do
-      with_feature_and_strategy do |strategy, feature|
-        subject.clear_feature! 'world_domination', 'test'
-        assert_nil strategy.enabled?(feature.key)
-      end
-    end
-
     describe 'when the strategy is not switchable' do
       it 'raises an error' do
         with_feature_and_strategy 'Lambda' do |strategy, feature|
           -> { subject.switch_feature!('world_domination', 'lambda', true) }.must_raise
         end
+      end
+    end
+  end
+
+  describe '#clear_feature!' do
+    it 'clears a feature using a strategy' do
+      with_feature_and_strategy do |strategy, feature|
+        subject.clear_feature! 'world_domination', 'test'
+        assert_nil strategy.enabled?(feature.key)
       end
     end
   end

--- a/test/unit/tasks/support/methods_test.rb
+++ b/test/unit/tasks/support/methods_test.rb
@@ -1,0 +1,66 @@
+require File.expand_path('../../../../test_helper', __FILE__)
+require File.expand_path('../../../../../lib/tasks/support/methods', __FILE__)
+
+describe Flipflop::Rake::SupportMethods do
+  subject do
+    object = Object.new
+    object.extend Flipflop::Rake::SupportMethods
+  end
+
+  describe '#status_label' do
+    it 'returns the "enabled" label when its argument is "true"' do
+      assert_equal 'ON', subject.status_label(true)
+    end
+
+    it 'returns the "disabled" label when its argument is "false"' do
+      assert_equal 'OFF', subject.status_label(false)
+    end
+
+    it 'returns the "unset" label when its argument is "nil"' do
+      assert_equal '', subject.status_label(nil)
+    end
+  end
+
+  describe '#switch_feature!' do
+    def with_feature_and_strategy(strategy = 'Test')
+      # Stubs finder methods to avoid going into FeatureSet code.
+      feature = Flipflop::FeatureDefinition.new(:world_domination)
+      subject.stub :find_feature_by_name, feature do
+        classname = "#{strategy}Strategy"
+        strategy = Flipflop::Strategies.const_get(classname).new(name: strategy)
+        subject.stub :find_strategy_by_name, strategy do
+          yield(strategy, feature) if block_given?
+        end
+      end
+    end
+
+    it 'enables a feature using a strategy' do
+      with_feature_and_strategy do |strategy, feature|
+        subject.switch_feature! 'world_domination', 'test', true
+        assert_equal true, strategy.enabled?(feature.key)
+      end
+    end
+
+    it 'disables a feature using a strategy' do
+      with_feature_and_strategy do |strategy, feature|
+        subject.switch_feature! 'world_domination', 'test', false
+        assert_equal false, strategy.enabled?(feature.key)
+      end
+    end
+
+    it 'clears a feature using a strategy' do
+      with_feature_and_strategy do |strategy, feature|
+        subject.clear_feature! 'world_domination', 'test'
+        assert_nil strategy.enabled?(feature.key)
+      end
+    end
+
+    describe 'when the strategy is not switchable' do
+      it 'raises an error' do
+        with_feature_and_strategy 'Lambda' do |strategy, feature|
+          -> { subject.switch_feature!('world_domination', 'lambda', true) }.must_raise
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hey guys, I noticed Flipflop doesn't have a way to manage features via console out of the box, so here's this PR built from work I had to do in one of my projects.

This adds a set of rake tasks that allow the user to control features the same way they can currently do it in the Dashboard.

These are the new tasks:

```
rake flipflop:features                    # Shows features table
rake flipflop:turn_on[feature,strategy]   # Enables a feature with the specified strategy
rake flipflop:turn_off[feature,strategy]  # Disables a feature with the specified strategy
```

For example, let's say you have a `config/features.rb` file like this:

```ruby
Flipflop.configure do
  strategy :cookie
  strategy :active_record
  strategy :default

  feature :world_domination, default: false
  feature :peace_among_worlds, default: false
end
```

To enable `:peace_among_worlds` using `:active_record` you would do:
```
bundle exec rake flipflop:turn_on[peace_among_worlds,active_record]
# => Feature :peace_among_worlds enabled!
```

To disable `:world_domination` using `:cookie` you would do:
```
bundle exec rake flipflop:turn_off[world_domination,cookie]
# => Feature :world_domination disabled!
```

To see the current state of your features you would do:
```
bundle exec rake flipflop:features

# => ┌──────────────────┬───────────┬──────┬─────────────┬───────┐
# => │feature           │description│cookie│active_record│default│
# => ├──────────────────┼───────────┼──────┼─────────────┼───────┤
# => │world_domination  │           │OFF   │             │OFF    │
# => ├──────────────────┼───────────┼──────┼─────────────┼───────┤
# => │peace_among_worlds│           │      │ON           │OFF    │
# => └──────────────────┴───────────┴──────┴─────────────┴───────┘
```

Thanks for such a great gem, guys!
