### PR TITLE
fix: rails 6 deprecation warnings with autoloader

### DIFF
--- a/lib/flipflop/engine.rb
+++ b/lib/flipflop/engine.rb
@@ -43,8 +43,14 @@ module Flipflop
 
     initializer "flipflop.request_interceptor" do |app|
       interceptor = Strategies::AbstractStrategy::RequestInterceptor
-      ActionController::Base.send(:include, interceptor)
-      ActionController::API.send(:include, interceptor) if defined?(ActionController::API)
+      
+      ActiveSupport.on_load(:action_controller_base) do
+        ActionController::Base.send(:include, interceptor)
+      end
+
+      ActiveSupport.on_load(:action_controller_api) do
+        ActionController::API.send(:include, interceptor)
+      end
     end
 
     def run_tasks_blocks(app)


### PR DESCRIPTION
Rails 6 introduces a new autoloading framework that doesn't allow initializers to use the autoloading system.

```
DEPRECATION WARNING: Initialization autoloaded the constants ActionText::ContentHelper and ActionText::TagHelper.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload ActionText::ContentHelper, for example,
the expected changes won't be reflected in that stale Module object.

These autoloaded constants have been unloaded.

Please, check the "Autoloading and Reloading Constants" guide for solutions.
```

This patch simply follows suite with what other gems have done to maintain compatibility such as Sorcery: https://github.com/Sorcery/sorcery/pull/209/files

Master Rails here: https://github.com/rails/rails/issues/36546