### PR TITLE
Fix Rails 6 deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,10 +15,12 @@ group :test do
   gem "fakeredis", require: false
 
   if version == "master" || version >= "6"
-    gem 'sassc-rails'
     gem "sqlite3", "~> 1.4.0", platform: :ruby
   else
     gem "sqlite3", "~> 1.3.6", platform: :ruby
+  end
+  if version >= "5.2" || Gem::Version.new(RUBY_VERSION) > Gem::Version.new("2.4.4")
+    gem 'sassc-rails'
   end
 
   gem "activerecord-jdbcsqlite3-adapter", platform: :jruby,

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :test do
   end
 
   gem "bootstrap", "= 4.0.0.alpha6", require: false
+  gem 'sassc-rails'
 
   gem "fakeredis", require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,11 @@ group :test do
   end
 
   gem "bootstrap", "= 4.0.0.alpha6", require: false
-  gem 'sassc-rails'
 
   gem "fakeredis", require: false
 
   if version == "master" || version >= "6"
+    gem 'sassc-rails'
     gem "sqlite3", "~> 1.4.0", platform: :ruby
   else
     gem "sqlite3", "~> 1.3.6", platform: :ruby

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,0 +1,3 @@
+//= link_tree ../images
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css

--- a/lib/flipflop/engine.rb
+++ b/lib/flipflop/engine.rb
@@ -35,7 +35,7 @@ module Flipflop
       next if rake_task_executing
       if actions = config.flipflop.dashboard_access_filter
         to_prepare do
-          ActiveSupport.on_load :action_controller do
+          ActiveSupport.on_load :application_controller do
             Flipflop::FeaturesController.before_action(*actions)
             Flipflop::StrategiesController.before_action(*actions)
           end

--- a/lib/flipflop/engine.rb
+++ b/lib/flipflop/engine.rb
@@ -35,10 +35,8 @@ module Flipflop
       next if rake_task_executing
       if actions = config.flipflop.dashboard_access_filter
         to_prepare do
-          ActiveSupport.on_load :application_controller do
-            Flipflop::FeaturesController.before_action(*actions)
-            Flipflop::StrategiesController.before_action(*actions)
-          end
+          Flipflop::FeaturesController.before_action(*actions)
+          Flipflop::StrategiesController.before_action(*actions)
         end
       end
     end

--- a/lib/flipflop/engine.rb
+++ b/lib/flipflop/engine.rb
@@ -34,8 +34,8 @@ module Flipflop
     initializer "flipflop.dashboard", after: "flipflop.features_reloader" do |app|
       next if rake_task_executing
       if actions = config.flipflop.dashboard_access_filter
-        ActiveSupport.on_load :action_controller do
-          to_prepare do
+        to_prepare do
+          ActiveSupport.on_load :action_controller do
             Flipflop::FeaturesController.before_action(*actions)
             Flipflop::StrategiesController.before_action(*actions)
           end

--- a/lib/flipflop/engine.rb
+++ b/lib/flipflop/engine.rb
@@ -34,17 +34,21 @@ module Flipflop
     initializer "flipflop.dashboard", after: "flipflop.features_reloader" do |app|
       next if rake_task_executing
       if actions = config.flipflop.dashboard_access_filter
-        to_prepare do
-          Flipflop::FeaturesController.before_action(*actions)
-          Flipflop::StrategiesController.before_action(*actions)
+        ActiveSupport.on_load :action_controller do
+          to_prepare do
+            Flipflop::FeaturesController.before_action(*actions)
+            Flipflop::StrategiesController.before_action(*actions)
+          end
         end
       end
     end
 
     initializer "flipflop.request_interceptor" do |app|
       interceptor = Strategies::AbstractStrategy::RequestInterceptor
-      ActionController::Base.send(:include, interceptor)
-      ActionController::API.send(:include, interceptor) if defined?(ActionController::API)
+      ActiveSupport.on_load :action_controller do
+        include interceptor
+        include interceptor if defined?(ActionController::API)
+      end
     end
 
     def run_tasks_blocks(app)

--- a/lib/flipflop/engine.rb
+++ b/lib/flipflop/engine.rb
@@ -45,9 +45,12 @@ module Flipflop
 
     initializer "flipflop.request_interceptor" do |app|
       interceptor = Strategies::AbstractStrategy::RequestInterceptor
-      ActiveSupport.on_load :action_controller do
-        include interceptor
-        include interceptor if defined?(ActionController::API)
+      ActiveSupport.on_load(:action_controller_base) do
+        ActionController::Base.send(:include, interceptor)
+      end
+
+      ActiveSupport.on_load(:action_controller_api) do
+        ActionController::API.send(:include, interceptor)
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -181,9 +181,10 @@ class TestApp
 
     if defined?(ActiveRecord::Migrator.migrate)
       ActiveRecord::Migrator.migrate(Rails.application.paths["db/migrate"].to_a)
-    else
-      # Rails 5.2+
+    elsif ActiveRecord::Base.connection.respond_to?(:schema_migration)
       ActiveRecord::MigrationContext.new(Rails.application.paths["db/migrate"], ActiveRecord::Base.connection.schema_migration).migrate
+    else
+      ActiveRecord::MigrationContext.new(Rails.application.paths["db/migrate"]).migrate
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -183,7 +183,7 @@ class TestApp
       ActiveRecord::Migrator.migrate(Rails.application.paths["db/migrate"].to_a)
     else
       # Rails 5.2+
-      ActiveRecord::MigrationContext.new(Rails.application.paths["db/migrate"]).migrate
+      ActiveRecord::MigrationContext.new(Rails.application.paths["db/migrate"], ActiveRecord::Base.connection.schema_migration).migrate
     end
   end
 

--- a/test/unit/strategies/cookie_strategy_test.rb
+++ b/test/unit/strategies/cookie_strategy_test.rb
@@ -112,7 +112,7 @@ describe Flipflop::Strategies::CookieStrategy do
         subject.switch!(:one, true)
         subject.clear!(:one)
         subject.send(:request).cookie_jar.write(headers = {})
-        assert_equal "my_cookie_one=; domain=.example.com; path=/foo; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 -0000; HttpOnly",
+        assert_equal "my_cookie_one=; domain=.example.com; path=/foo; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly",
           headers["Set-Cookie"]
       end
     end


### PR DESCRIPTION
Zeitwerk friendly update to avoid triggering `ActionController` to be loaded on initialize.
See: https://github.com/rails/rails/issues/36546