### PR TITLE
Pivot to GitHub Actions

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_GITHUB__HTTPS: "true"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,76 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      matrix:
+        ruby:
+          - ruby-head
+          - jruby-head
+        rails:
+          - 7
+          - master
+        rails_api_only:
+          - 0
+          - 1
+        jruby_ar_jdbc_adapter_version:
+          - v70.0.pre
+        experimental:
+          - true
+        include:
+          - ruby: 2.7
+            rails: 5
+            rails_api_only: 0
+            experimental: false
+          - ruby: 2.7
+            rails: 5
+            rails_api_only: 1
+            experimental: false
+          - ruby: 2.7
+            rails: 6
+            rails_api_only: 0
+            experimental: false
+          - ruby: 2.7
+            rails: 6
+            rails_api_only: 1
+            experimental: false
+          - ruby: 3.1
+            rails: 7
+            rails_api_only: 0
+            experimental: false
+          - ruby: 3.1
+            rails: 7
+            rails_api_only: 1
+            experimental: false
+          - ruby: jruby-9.1
+            rails: 5
+            rails_api_only: 0
+            jruby_ar_jdbc_adapter_version: v52.8
+            experimental: false
+          - ruby: jruby-9.2
+            rails: 6
+            rails_api_only: 0
+            jruby_ar_jdbc_adapter_version: v60.0
+            experimental: false
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+      env:
+        RAILS_VERSION: ${{ matrix.rails }}
+        RAILS_API_ONLY: ${{ matrix.rails_api_only }}
+        JRUBY_AR_JDBC_ADAPTER_VERSION: ${{ matrix.jruby_ar_jdbc_adapter_version }}
+    - run: bundle exec rake
+      env:
+        RAILS_VERSION: ${{ matrix.rails }}
+        RAILS_API_ONLY: ${{ matrix.rails_api_only }}
+        JRUBY_AR_JDBC_ADAPTER_VERSION: ${{ matrix.jruby_ar_jdbc_adapter_version }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.gem
-.bundle
 Gemfile.lock
+
 pkg/*
 tmp/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,48 +1,6 @@
 language: ruby
 cache: bundler
-rvm:
-- 2.5.0
-- 2.4.4
-- 2.3.5
-- jruby-9.1.13.0
-- ruby-head
-- jruby-head
-env:
-- RAILS_VERSION=master
-- RAILS_VERSION=master RAILS_API_ONLY=1
-- RAILS_VERSION=5.2
-- RAILS_VERSION=5.2 RAILS_API_ONLY=1
-- RAILS_VERSION=5.1
-- RAILS_VERSION=5.1 RAILS_API_ONLY=1
-- RAILS_VERSION=5.0
-- RAILS_VERSION=5.0 RAILS_API_ONLY=1
-matrix:
-  include:
-  - rvm: 2.2.8
-    env: RAILS_VERSION=4.2
-  - rvm: 2.1.10
-    env: RAILS_VERSION=4.2
-  - rvm: 2.0.0
-    env: RAILS_VERSION=4.2
-  - rvm: 2.2.8
-    env: RAILS_VERSION=4.1
-  - rvm: 2.1.10
-    env: RAILS_VERSION=4.1
-  - rvm: 2.0.0
-    env: RAILS_VERSION=4.1
-  exclude:
-  - rvm: 2.4.4
-    env: RAILS_VERSION=master
-  - rvm: 2.4.4
-    env: RAILS_VERSION=master RAILS_API_ONLY=1
-  - rvm: 2.3.5
-    env: RAILS_VERSION=master
-  - rvm: 2.3.5
-    env: RAILS_VERSION=master RAILS_API_ONLY=1
-  allow_failures:
-  - rvm: jruby-9.1.13.0
-  - rvm: ruby-head
-  - rvm: jruby-head
+ruby: 2.5.0
 before_deploy: bundle exec rake assets:compile
 deploy:
   provider: rubygems

--- a/Gemfile
+++ b/Gemfile
@@ -23,8 +23,10 @@ group :test do
     gem 'sassc-rails'
   end
 
-  gem "activerecord-jdbcsqlite3-adapter", platform: :jruby,
-    github: "jruby/activerecord-jdbc-adapter"
+  if RUBY_PLATFORM == 'java'
+    gem "activerecord-jdbcsqlite3-adapter", platform: :jruby,
+      github: "jruby/activerecord-jdbc-adapter", tag: ENV['JRUBY_AR_JDBC_ADAPTER_VERSION']
+  end
 
   gem "minitest", ">= 4.2"
   gem "capybara", ">= 2.6"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[<img src="https://travis-ci.org/voormedia/flipflop.svg?branch=master" alt="Build Status">](https://travis-ci.org/voormedia/flipflop)
+![GitHub Actions](https://github.com/voormedia/flipflop/actions/workflows/test.yml/badge.svg)
 
 # Flipflop your features
 

--- a/lib/flipflop/configurable.rb
+++ b/lib/flipflop/configurable.rb
@@ -15,10 +15,10 @@ module Flipflop
       FeatureSet.current.add(feature)
     end
 
-    def strategy(strategy = nil, **options)
+    def strategy(strategy = nil, **options, &block)
       if block_given?
         options[:name] = strategy.to_s
-        options[:lambda] = Proc.new
+        options[:lambda] = block
         strategy = Strategies::LambdaStrategy
       end
 

--- a/lib/flipflop/facade.rb
+++ b/lib/flipflop/facade.rb
@@ -11,6 +11,8 @@ module Flipflop
     end
 
     def respond_to_missing?(method, include_private = false)
+      return false if method == :use_relative_model_naming?
+
       method[-1] == "?"
     end
 

--- a/lib/flipflop/strategies/cookie_strategy.rb
+++ b/lib/flipflop/strategies/cookie_strategy.rb
@@ -32,7 +32,8 @@ module Flipflop
       end
 
       def clear!(feature)
-        request.cookie_jar.delete(cookie_key(feature), **@options)
+        options = @options.dup
+        request.cookie_jar.delete(cookie_key(feature), **options)
       end
 
       protected

--- a/test/unit/feature_definition_test.rb
+++ b/test/unit/feature_definition_test.rb
@@ -32,7 +32,7 @@ describe Flipflop::FeatureDefinition do
 
     it "should have location" do
       # Because we have no indirection via FeatureSet, the location is minitest.
-      assert_equal "instance_eval", subject.location.label
+      assert ["block in let", "instance_eval"].include?(subject.location.label)
     end
   end
 
@@ -71,7 +71,8 @@ describe Flipflop::FeatureDefinition do
 
     it "should have location" do
       # Because we have no indirection via FeatureSet, the location is minitest.
-      assert_equal "instance_eval", subject.location.label
+      expected = RUBY_PLATFORM == "java" ? "block in let" : "instance_eval"
+      assert_equal expected, subject.location.label
     end
   end
 

--- a/test/unit/tasks/support/methods_test.rb
+++ b/test/unit/tasks/support/methods_test.rb
@@ -51,7 +51,7 @@ describe Flipflop::Rake::SupportMethods do
     describe 'when the strategy is not switchable' do
       it 'raises an error' do
         with_feature_and_strategy 'Lambda' do |strategy, feature|
-          -> { subject.switch_feature!('world_domination', 'lambda', true) }.must_raise
+          _{ subject.switch_feature!('world_domination', 'lambda', true) }.must_raise
         end
       end
     end


### PR DESCRIPTION
In late 2020, Travis CI decided to discontinue unlimited free builds
for public projects. While they still hand out free build minutes
for opensource project, they do this through an application process,
thereby making it difficult to quickly contribure:

https://www.jeffgeerling.com/blog/2020/travis-cis-new-pricing-plan-threw-wrench-my-open-source-works

Since GitHub Actions still allows unlimited build time for public
project, it became the go-to CI for opensource projects on GitHub.

We also update the test build to include Rails 6 and 7.