### PR TITLE
Adding anchor feature to flipflop features

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 2.7.1
+
+* Admin page redirection enhancements after updating a feature switch. Now after flipping a switch it will take you back to the section that you were navigating previously. This is very helpful when having several feature switches.
+
 ## 2.7.0
 
 * Removing .css extension from render partial and adding it to html handler to correctly render the erb file.

--- a/app/controllers/flipflop/strategies_controller.rb
+++ b/app/controllers/flipflop/strategies_controller.rb
@@ -4,12 +4,12 @@ module Flipflop
 
     def update
       FeatureSet.current.switch!(feature_key, strategy_key, enable?)
-      redirect_to(features_url)
+      redirect_to features_url(anchor: "#{feature_key}-#{strategy_key}".parameterize)
     end
 
     def destroy
       FeatureSet.current.clear!(feature_key, strategy_key)
-      redirect_to(features_url)
+      redirect_to features_url(anchor: "#{feature_key}-#{strategy_key}".parameterize)
     end
 
     private

--- a/app/views/flipflop/features/index.html.erb
+++ b/app/views/flipflop/features/index.html.erb
@@ -41,7 +41,7 @@
           </td>
 
           <% @feature_set.strategies.each do |strategy| -%>
-            <td class="toggle" data-strategy="<%= strategy.name.dasherize.parameterize %>">
+            <td class="toggle" data-strategy="<%= strategy.name.dasherize.parameterize %>" id="<%= "#{feature.key}-#{strategy.key}".parameterize %>">
               <div class="toolbar">
                 <%= form_tag(@feature_set.switch_url(strategy, feature), method: :put) do -%>
                   <div class="group">

--- a/lib/flipflop/version.rb
+++ b/lib/flipflop/version.rb
@@ -1,3 +1,3 @@
 module Flipflop
-  VERSION = "2.7.0"
+  VERSION = "2.7.1"
 end


### PR DESCRIPTION
@emielvanlankveld @rolftimmermans 

This PR enhances admin page redirection after updating a feature switch. Now after flipping a switch it will take you back to the section that you were navigating previously. This is very helpful when having several feature switches.